### PR TITLE
misc: Add English Language

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -47,7 +47,9 @@
             Use "Monkey C: Edit Languages" from the Visual Studio Code command
             palette to edit your compatible language list.
         -->
-        <iq:languages/>
+        <iq:languages>
+          <iq:language>eng</iq:language>
+        </iq:languages>
         <!--
             Use "Monkey C: Configure Monkey Barrel" from the Visual Studio Code
             command palette to edit the included barrels.


### PR DESCRIPTION
Mostly to remove a build warning by the MonkeyC compiler and keep the output of `build.sh` fairly clean.